### PR TITLE
fix: use datetime for user soft delete

### DIFF
--- a/backend/internal/service/user_management.go
+++ b/backend/internal/service/user_management.go
@@ -436,7 +436,7 @@ func (s *UserManagementService) DeleteUser(userID int64, hardDelete bool) (int64
 	}
 
 	// Soft delete
-	now := time.Now().Unix()
+	now := time.Now()
 	affected, err := s.db.Execute(s.db.RebindQuery(
 		"UPDATE users SET deleted_at = ? WHERE id = ? AND deleted_at IS NULL"), now, userID)
 	if err != nil {
@@ -512,17 +512,18 @@ func (s *UserManagementService) PurgeSoftDeleted(dryRun bool) (int64, error) {
 
 // BatchDeleteInactiveUsers deletes inactive users
 func (s *UserManagementService) BatchDeleteInactiveUsers(activityLevel string, dryRun, hardDelete bool) (map[string]interface{}, error) {
-	now := time.Now().Unix()
+	now := time.Now()
+	nowUnix := now.Unix()
 	var condition string
 
 	switch activityLevel {
 	case ActivityNever:
 		condition = "request_count = 0"
 	case ActivityVeryInactive:
-		threshold := now - InactiveThreshold
+		threshold := nowUnix - InactiveThreshold
 		condition = fmt.Sprintf("request_count > 0 AND id NOT IN (SELECT DISTINCT user_id FROM logs WHERE type IN (2,5) AND created_at >= %d)", threshold)
 	case ActivityInactive:
-		threshold := now - ActiveThreshold
+		threshold := nowUnix - ActiveThreshold
 		condition = fmt.Sprintf("request_count > 0 AND id NOT IN (SELECT DISTINCT user_id FROM logs WHERE type IN (2,5) AND created_at >= %d)", threshold)
 	default:
 		return nil, fmt.Errorf("invalid activity level: %s", activityLevel)
@@ -551,8 +552,11 @@ func (s *UserManagementService) BatchDeleteInactiveUsers(activityLevel string, d
 		s.db.Execute(fmt.Sprintf(
 			"DELETE FROM users WHERE deleted_at IS NULL AND role != 100 AND %s", condition))
 	} else {
-		s.db.Execute(fmt.Sprintf(
-			"UPDATE users SET deleted_at = %d WHERE deleted_at IS NULL AND role != 100 AND %s", now, condition))
+		_, err = s.db.Execute(s.db.RebindQuery(fmt.Sprintf(
+			"UPDATE users SET deleted_at = ? WHERE deleted_at IS NULL AND role != 100 AND %s", condition)), now)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	logger.L.Business(fmt.Sprintf("批量删除 %s 用户: %d 个", activityLevel, affected))


### PR DESCRIPTION
This fixes a compatibility issue with deployments that share the upstream 
ew-api MySQL schema.

Problem:
- users.deleted_at is commonly datetime(3) in 
ew-api
- 
ew_api_tools soft-delete code writes Unix timestamps (	ime.Now().Unix()) into deleted_at
- on MySQL this causes delete-user requests to fail with Incorrect datetime value, and changing the shared column to BIGINT breaks 
ew-api with scan errors like unsupported Scan, storing driver.Value type int64 into type *time.Time

Fix:
- write 	ime.Time for single-user soft delete
- write 	ime.Time for batch soft delete
- keep Unix timestamps only for activity threshold calculations
- surface batch update errors instead of ignoring them

Validated on a live deployment:
- upstream 
ew-api kept working with users.deleted_at = datetime(3)
- DELETE /api/users/:id?hard_delete=false returned 200 after the change